### PR TITLE
target: Fix Hang Tasks from Unsupported Scsi OP

### DIFF
--- a/drivers/target/target_core_transport.c
+++ b/drivers/target/target_core_transport.c
@@ -1684,7 +1684,8 @@ void transport_generic_request_failure(struct se_cmd *cmd,
 	/*
 	 * For SAM Task Attribute emulation for failed struct se_cmd
 	 */
-	transport_complete_task_attr(cmd);
+	if (sense_reason != TCM_UNSUPPORTED_SCSI_OPCODE)
+		transport_complete_task_attr(cmd);
 	/*
 	 * Handle special case for COMPARE_AND_WRITE failure, where the
 	 * callback is expected to drop the per device ->caw_sem.


### PR DESCRIPTION
If a Simple command is sent with an Unsupported SCSI Opcode (failure),
target_setup_cmd_from_cdb returns with TCM_UNSUPPORTED_SCSI_OPCODE
which then causes transport_generic_request_failure to decrement
simple_cmds, due to call to transport_complete_task_attr.
With this dev->simple_cmds or dev->dev_ordered_sync is now -1, not 0.
So when a subsequent command with an Ordered Task is sent, it causes
a hang, since dev->simple_cmds is at -1. Thus to prevent Unsupported
SCSI Opcode Failure from decrementing simple_cmds I added a check
to skip transport_complete_task_attr for sense_reaons that are
TCM_UNSUPPORTED_SCSI_OPCODE.

I dont know if this is a proper fix, but it worked for me, let me
know what you think Nick.

Signed-off-by: Bryant G. Ly bryantly@linux.vnet.ibm.com
