### PR TITLE
Fix unmap_zeroes_data_store return value

### DIFF
--- a/drivers/target/target_core_configfs.c
+++ b/drivers/target/target_core_configfs.c
@@ -995,7 +995,7 @@ static ssize_t unmap_zeroes_data_store(struct config_item *item,
 	da->unmap_zeroes_data = flag;
 	pr_debug("dev[%p]: SE Device Thin Provisioning LBPRZ bit: %d\n",
 		 da->da_dev, flag);
-	return 0;
+	return count;
 }
 
 /*


### PR DESCRIPTION
Writing to /sys/kernel/config/target/core/fileio_X/NAME/attrib/unmap_zeroes_data
causes a hang. This can occur when doing a `targetctl clear` followed
by systemctl restart lio-target with a fileio backstore.